### PR TITLE
Теперь имя "владельца метода" заполняется во время семантического ана…

### DIFF
--- a/Interpreter.Lib/Semantic/Nodes/Expressions/AssignmentExpression.cs
+++ b/Interpreter.Lib/Semantic/Nodes/Expressions/AssignmentExpression.cs
@@ -66,7 +66,7 @@ namespace Interpreter.Lib.Semantic.Nodes.Expressions
                     : type;
                 if (typeOfSymbol is ObjectType)
                 {
-                    SymbolTable.AddSymbol(new ObjectSymbol(id, declaration.Const())
+                    SymbolTable.AddSymbol(new ObjectSymbol(id, declaration.Const(), _source.SymbolTable, typeOfSymbol)
                     {
                         Type = typeOfSymbol,
                         Table = _source.SymbolTable

--- a/Interpreter.Lib/Semantic/Nodes/Expressions/CallExpression.cs
+++ b/Interpreter.Lib/Semantic/Nodes/Expressions/CallExpression.cs
@@ -158,7 +158,7 @@ namespace Interpreter.Lib.Semantic.Nodes.Expressions
                 instructions.AddRange(_ident.ToInstructions(start, temp));
                 function.CallInfo.MethodOf = instructions.Any()
                     ? instructions.OfType<Simple>().Last().Left
-                    : _ident.Id;
+                    : function.CallInfo.MethodOf;
                 instructions.Add(
                     new PushParameter(
                         start + instructions.Count,

--- a/Interpreter.Lib/Semantic/Symbols/ObjectSymbol.cs
+++ b/Interpreter.Lib/Semantic/Symbols/ObjectSymbol.cs
@@ -1,9 +1,22 @@
+using Interpreter.Lib.Semantic.Types;
+
 namespace Interpreter.Lib.Semantic.Symbols
 {
     public class ObjectSymbol : VariableSymbol
     {
-        public ObjectSymbol(string id, bool readOnly = false) : base(id, readOnly)
+        public ObjectSymbol(string id, bool readOnly = false, SymbolTable table = null, Type type = null) : base(id, readOnly)
         {
+            if (table != null && type is ObjectType objectType)
+            {
+                foreach (var key in objectType.Keys)
+                {
+                    if (objectType[key] is FunctionType)
+                    {
+                        var function = table.FindSymbol<FunctionSymbol>(key);
+                        function.CallInfo.MethodOf = id;
+                    }
+                }
+            }
         }
 
         public SymbolTable Table { get; init; }

--- a/Interpreter.Lib/Semantic/Types/ObjectType.cs
+++ b/Interpreter.Lib/Semantic/Types/ObjectType.cs
@@ -23,6 +23,8 @@ namespace Interpreter.Lib.Semantic.Types
             ? _properties[id]
             : null;
 
+        public IEnumerable<string> Keys => _properties.Keys;
+
         public void ResolveSelfReferences(string self)
         {
             foreach (var (key, property) in _properties)


### PR DESCRIPTION
На данный момент, если у объекта есть метод, который не вызывается, то в промежуточном представлении не указывается, что этот метод принадлежит именно этому объекту.
Пример:
```
let vector2 = {
    x: 0;
    y: 0;
    lengthSquared => (): number {
        return x * x + y * y
    };
}
```
```
0: Goto 6
1: BeginFunction lengthSquared
2: _t2 = x * x
3: _t3 = y * y
4: _t4 = _t2 + _t3
5: Return _t4
6: object vector2 = {}
7: vector2.\"x\" = 0
8: vector2.\"y\" = 0
9: End
```
Эта информация заполняется только во время создания инструкций для выражений вызова функции. Соответственно, инструкция под номером 1 должна выглядеть так:
```
1: BeginFunction vector2.lengthSquared
```